### PR TITLE
Wil 20 strona aktualności

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,5 @@
 name: "Pull Request Labeler"
-on: [ pull_request ]
+on: [ pull_request_target ]
 
 jobs:
   labeler:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      labels: write
     
     steps:
     - id: Checkout

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,7 +8,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      labels: write
+      issues: write
+      checks: write
     
     steps:
     - id: Checkout

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,5 @@
 name: "Pull Request Labeler"
-on: [ pull_request_target ]
+on: [ pull_request ]
 
 jobs:
   labeler:


### PR DESCRIPTION
## Podsumowanie od Sourcery

Aktualizacja workflow etykietowania GitHub, aby uruchamiał się na `pull_request_target` i przyznanie niezbędnych uprawnień

CI:
- Zmiana wyzwalacza workflow z `pull_request` na `pull_request_target`
- Dodanie uprawnień `issues:write` i `checks:write` do zadania etykietowania

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub labeler workflow to trigger on pull_request_target and grant necessary permissions

CI:
- Change workflow trigger from pull_request to pull_request_target
- Add issues:write and checks:write permissions to labeler job

</details>