### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,12 @@
 pull_request_rules:
+  - name: Add a queue label when PR is queued
+    description: Toggle the queue label when a pull request is (un)queued.
+    conditions:
+      - queue-position > 0
+    actions:
+      label:
+        toggle:
+          - merge-queued
   - name: Make sure PR are up to date before merging with rebase
     description: This automatically rebases PRs when they are out-of-date with the
       base branch to avoid semantic conflicts (next step is using a merge
@@ -47,3 +55,12 @@ pull_request_rules:
       label:
         toggle:
           - stack
+merge_protections:
+  - name: Enforce conventional commit
+    description: Make sure that we follow https://www.conventionalcommits.org/en/v1.0.0/
+    if:
+      - base = main
+    success_conditions:
+      - "title ~=
+        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\
+        \\))?:"


### PR DESCRIPTION
This change has been made by @reisene from the Mergify workflow automation editor.

## Podsumowanie od Sourcery

Aktualizacja konfiguracji Mergify w celu dodania automatyzacji etykietowania kolejek dla PR-ów oraz wymuszenia standardów konwencji commitów przy merge'owaniu do `main`.

CI:
- Dodano regułę pull request, która przełącza etykietę 'merge-queued' dla PR-ów w kolejce.
- Dodano ochronę merge'owania, aby wymusić formatowanie zgodne z konwencją commitów w tytułach PR-ów kierowanych do `main`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Mergify configuration to add queue label automation for PRs and enforce conventional commit standards on merges to main.

CI:
- Add pull request rule to toggle a 'merge-queued' label for queued PRs
- Add merge protection to enforce conventional commit formatting on PR titles targeting main

</details>