### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,4 @@
 pull_request_rules:
-  - name: Add a queue label when PR is queued
-    description: Toggle the queue label when a pull request is (un)queued.
-    conditions:
-      - queue-position > 0
-    actions:
-      label:
-        toggle:
-          - merge-queued
   - name: Make sure PR are up to date before merging with rebase
     description: This automatically rebases PRs when they are out-of-date with the
       base branch to avoid semantic conflicts (next step is using a merge
@@ -55,12 +47,3 @@ pull_request_rules:
       label:
         toggle:
           - stack
-merge_protections:
-  - name: Enforce conventional commit
-    description: Make sure that we follow https://www.conventionalcommits.org/en/v1.0.0/
-    if:
-      - base = main
-    success_conditions:
-      - "title ~=
-        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\
-        \\))?:"


### PR DESCRIPTION
This change has been made by @reisene from the Mergify merge protections editor.

## Podsumowanie od Sourcery

Oczyszczenie konfiguracji Mergify poprzez usunięcie przestarzałych reguł pull request i zabezpieczeń.

CI:
- Usunięcie wpisu "Add a queue label when PR is queued" w `pull_request_rules`
- Usunięcie sekcji `merge_protections` wymuszającej konwencjonalne tytuły commitów na gałęzi głównej (main branch)

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up Mergify configuration by removing obsolete pull request rules and protections.

CI:
- Remove the "Add a queue label when PR is queued" pull_request_rules entry
- Delete the merge_protections section enforcing conventional commit titles on the main branch

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Usunięto zduplikowaną regułę dotyczącą etykiety "merge-queued" dla pull requestów.
  - Usunięto wymaganie stosowania konwencjonalnego formatowania komunikatów commitów w tytułach PR kierowanych do głównej gałęzi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->