### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/reisene/wilczar.writer/security/code-scanning/2](https://github.com/reisene/wilczar.writer/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps:
- The `actions/checkout@v3` step requires `contents: read` permission to access the repository's files.
- The deployment step may require no repository permissions, as it uses an external service (`curl "$deploy_url"`).

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `ci` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
